### PR TITLE
Add Support for Export to ONNX and Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python infer_onnx.py --model {path_to_exported}.onnx --config-path config.json -
 ```
 
 
-Please note that to export to ONNX and run inference, additional packages must be installed. After setting up the environment as described above, install the following packages. This setup has been tested with Python 3.8:
+Please note that to export to ONNX and run inference, additional packages must be installed. After setting up the environment as described above, install the following packages. This setup has been tested with ```Python 3.8```:
 
 - For ONNX export: ```torch==1.12.0```
 - For ONNX inference: ```onnxruntime==1.18.0```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Please note that to export to ONNX and run inference, additional packages must b
 
 - For ONNX export: ```torch==1.12.0```
 - For ONNX inference: ```onnxruntime==1.18.0```
+Additionally, please upgrade ```numpy==1.23.5```
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ After the training, you can check inference audio using [inference.ipynb](infere
 ### 4. Export to ONNX and Inference
 In order to export your trained checkpoints to ONNX, please run the following script:
 ```sh
-python export_onnx.py  --model {model_ckpt.pth} --config-path config.json --output-onnx-path {path_to_exported}.onnx --device 'cpu'
+python export_onnx.py  --model {model_ckpt}.pth --config-path config.json --output-onnx-path {path_to_exported}.onnx --device 'cpu'
 ```
 
 Afterwards, you can use the exported onnx model to run inference as follows:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ python infer_onnx.py --model {path_to_exported}.onnx --config-path config.json -
 
 Please note that to export to ONNX and run inference, additional packages must be installed. After setting up the environment as described above, install the following packages. This setup has been tested with Python 3.8:
 
-For ONNX export: ```torch==1.12.0```
-For ONNX inference: ```onnxruntime==1.18.0```
+- For ONNX export: ```torch==1.12.0```
+- For ONNX inference: ```onnxruntime==1.18.0```
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ python train_latest.py -c configs/ljs_mb_istft_vits.json -m ljs_mb_istft_vits
 
 After the training, you can check inference audio using [inference.ipynb](inference.ipynb)
 
+
+
+### 4. Export to ONNX and Inference
+In order to export your trained checkpoints to ONNX, please run the following script:
+```sh
+python export_onnx.py  --model {model_ckpt.pth} --config-path config.json --output-onnx-path {path_to_exported}.onnx --device 'cpu'
+```
+
+Afterwards, you can use the exported onnx model to run inference as follows:
+```sh
+python infer_onnx.py --model {path_to_exported}.onnx --config-path config.json --output-wav-path output.wav --text "Hello world, how are you doing?"
+```
+
+
+Please note that to export to ONNX and run inference, additional packages must be installed. After setting up the environment as described above, install the following packages. This setup has been tested with Python 3.8:
+
+For ONNX export: ```torch==1.12.0```
+For ONNX inference: ```onnxruntime==1.18.0```
+
+
 ## References
 - https://github.com/jaywalnut310/vits.git
 - https://github.com/rishikksh20/iSTFTNet-pytorch.git

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -6,15 +6,14 @@ from models import SynthesizerTrn
 from text.symbols import symbols
 
 
-
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", required=True, help="Path to model (.onnx)")
+    parser.add_argument("--model", required=True, help="Path to model checkpoints")
     parser.add_argument(
         "--config-path", required=True, help="Path to model config (.json)"
     )
     parser.add_argument(
-        "--output-onnx-path", required=True, help="Path to write WAV file"
+        "--output-onnx-path", required=True, help="Path to write exported onnx model"
     )
     parser.add_argument("--device", required=True, type=str, help="Device to run onnx export", default="cpu")
     args = parser.parse_args()
@@ -37,7 +36,7 @@ def main() -> None:
         hps.train.segment_size // hps.data.hop_length,
         # n_speakers=hps.data.n_speakers, #- for multi speaker
         is_onnx=True,
-        **hps.model)
+        **hps.model).to(args.device)
 
     _ = utils.load_checkpoint(args.model, net_g, None)
 
@@ -58,7 +57,6 @@ def main() -> None:
 
         return audio
 
-
     with torch.no_grad():
         net_g.dec.remove_weight_norm()
         net_g.forward = infer_forward
@@ -68,12 +66,12 @@ def main() -> None:
     dummy_input_length = 50
     sequences = torch.randint(
         low=0, high=num_symbols, size=(1, dummy_input_length), dtype=torch.long
-    )
+    ).to(args.device)
     sequence_lengths = torch.LongTensor([sequences.size(1)]).to(args.device)
     sid = None
 
     # noise, noise_w, length
-    scales = torch.FloatTensor([0.667, 1.0, 0.8])
+    scales = torch.FloatTensor([0.667, 1.0, 0.8]).to(args.device)
     dummy_input = (sequences, sequence_lengths, scales, sid)
 
     # Export

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,0 +1,96 @@
+import torch
+import utils
+import argparse
+
+from models import SynthesizerTrn
+from text.symbols import symbols
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="Path to model (.onnx)")
+    parser.add_argument(
+        "--config-path", required=True, help="Path to model config (.json)"
+    )
+    parser.add_argument(
+        "--output-onnx-path", required=True, help="Path to write WAV file"
+    )
+    parser.add_argument("--device", required=True, type=str, help="Device to run onnx export", default="cpu")
+    args = parser.parse_args()
+
+
+    hps = utils.get_hparams_from_file(args.config_path)
+
+    if "use_mel_posterior_encoder" in hps.model.keys() and hps.model.use_mel_posterior_encoder == True:
+        print("Using mel posterior encoder for VITS2")
+        posterior_channels = 80  # vits2
+        hps.data.use_mel_posterior_encoder = True
+    else:
+        print("Using lin posterior encoder for VITS1")
+        posterior_channels = hps.data.filter_length // 2 + 1
+        hps.data.use_mel_posterior_encoder = False
+
+    net_g = SynthesizerTrn(
+        len(symbols),
+        posterior_channels,
+        hps.train.segment_size // hps.data.hop_length,
+        # n_speakers=hps.data.n_speakers, #- for multi speaker
+        is_onnx=True,
+        **hps.model)
+
+    _ = utils.load_checkpoint(args.model, net_g, None)
+
+    num_symbols = net_g.n_vocab
+    
+    def infer_forward(text, text_lengths, scales, sid=None):
+        noise_scale = scales[0]
+        length_scale = scales[1]
+        noise_scale_w = scales[2]
+        audio = net_g.infer(
+                text,
+                text_lengths,
+                noise_scale=noise_scale,
+                length_scale=length_scale,
+                noise_scale_w=noise_scale_w,
+                sid=sid,
+        )[0].unsqueeze(1)
+
+        return audio
+
+
+    with torch.no_grad():
+        net_g.dec.remove_weight_norm()
+        net_g.forward = infer_forward
+
+    net_g.eval()
+
+    dummy_input_length = 50
+    sequences = torch.randint(
+        low=0, high=num_symbols, size=(1, dummy_input_length), dtype=torch.long
+    )
+    sequence_lengths = torch.LongTensor([sequences.size(1)]).to(args.device)
+    sid = None
+
+    # noise, noise_w, length
+    scales = torch.FloatTensor([0.667, 1.0, 0.8])
+    dummy_input = (sequences, sequence_lengths, scales, sid)
+
+    # Export
+    torch.onnx.export(
+            model=net_g,
+            args=dummy_input,
+            f=args.output_onnx_path,
+            verbose=True,
+            opset_version=14,
+            input_names=["input", "input_lengths", "scales", "sid"],
+            output_names=["output"],
+            dynamic_axes={
+                "input": {0: "batch_size", 1: "phonemes"},
+                "input_lengths": {0: "batch_size"},
+                "output": {0: "batch_size", 1: "time"},
+            },
+    )
+
+if __name__ == "__main__":
+    main()

--- a/infer_onnx.py
+++ b/infer_onnx.py
@@ -28,10 +28,16 @@ def main() -> None:
         "--output-wav-path", required=True, help="Path to write WAV file"
     )
     parser.add_argument("--text", required=True, type=str, help="Text to synthesize")
+    parser.add_argument("--device", required=True, type=str, help="Device to run onnx export", default="cpu")
     args = parser.parse_args()
 
     sess_options = onnxruntime.SessionOptions()
-    model = onnxruntime.InferenceSession(str(args.model), sess_options=sess_options, providers=["CPUExecutionProvider"])
+    
+    providers = ["CPUExecutionProvider"]
+    if args.device == "cuda":
+        providers.append("CUDAExecutionProvider")
+
+    model = onnxruntime.InferenceSession(str(args.model), sess_options=sess_options, providers=providers)
 
     hps = utils.get_hparams_from_file(args.config_path)
 

--- a/infer_onnx.py
+++ b/infer_onnx.py
@@ -1,0 +1,57 @@
+import argparse
+
+import numpy as np
+import onnxruntime
+import torch
+import soundfile as sf
+    
+import commons
+import utils
+from text import text_to_sequence
+
+
+def get_text(text, hps):
+    text_norm = text_to_sequence(text, hps.data.text_cleaners)
+    if hps.data.add_blank:
+        text_norm = commons.intersperse(text_norm, 0)
+    text_norm = torch.LongTensor(text_norm)
+    return text_norm
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="Path to model (.onnx)")
+    parser.add_argument(
+        "--config-path", required=True, help="Path to model config (.json)"
+    )
+    parser.add_argument(
+        "--output-wav-path", required=True, help="Path to write WAV file"
+    )
+    parser.add_argument("--text", required=True, type=str, help="Text to synthesize")
+    args = parser.parse_args()
+
+    sess_options = onnxruntime.SessionOptions()
+    model = onnxruntime.InferenceSession(str(args.model), sess_options=sess_options, providers=["CPUExecutionProvider"])
+
+    hps = utils.get_hparams_from_file(args.config_path)
+
+    phoneme_ids = get_text(args.text, hps)
+    text = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
+    text_lengths = np.array([text.shape[1]], dtype=np.int64)
+    scales = np.array([0.667, 1.0, 0.8], dtype=np.float32)
+
+    audio = model.run(
+        None,
+        {
+            "input": text,
+            "input_lengths": text_lengths,
+            "scales": scales,
+            "sid": None,
+        },
+    )[0].squeeze((0, 1))
+    
+    sf.write(args.output_wav_path, audio, hps.data.sampling_rate)
+    
+
+if __name__ == "__main__":
+    main()

--- a/models.py
+++ b/models.py
@@ -1,20 +1,22 @@
-import copy
 import math
 import torch
-from torch import nn
-from torch.nn import functional as F
-
+import stft_onnx
 import commons
 import modules
 import attentions
 import monotonic_align
+import math
 
-from torch.nn import Conv1d, ConvTranspose1d, AvgPool1d, Conv2d
+from torch import nn
+from torch.nn import functional as F
+from torch.nn import Conv1d, ConvTranspose1d, Conv2d
 from torch.nn.utils import weight_norm, remove_weight_norm, spectral_norm
 from commons import init_weights, get_padding
 from pqmf import PQMF
 from stft import TorchSTFT
-import math
+from stft import STFT
+
+MAX_FRAMES = 5200
 
 
 class StochasticDurationPredictor(nn.Module):
@@ -210,6 +212,15 @@ class ResidualCouplingBlock(nn.Module):
       for flow in reversed(self.flows):
         x = flow(x, x_mask, g=g, reverse=reverse)
     return x
+  
+  def remove_weight_norm(self):
+      print('Removing weight norm...')
+      for l in self.flows:
+          try:
+            module = getattr(l, 'enc', None)
+            module.remove_weight_norm
+          except:
+            pass
 
 
 class PosteriorEncoder(nn.Module):
@@ -305,7 +316,7 @@ class iSTFT_Generator(torch.nn.Module):
 
 
 class Multiband_iSTFT_Generator(torch.nn.Module):
-    def __init__(self, initial_channel, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size, subbands, gin_channels=0):
+    def __init__(self, initial_channel, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size, subbands, gin_channels=0, is_onnx=False):
         super(Multiband_iSTFT_Generator, self).__init__()
         # self.h = h
         self.subbands = subbands
@@ -338,9 +349,29 @@ class Multiband_iSTFT_Generator(torch.nn.Module):
         self.gen_istft_n_fft = gen_istft_n_fft
         self.gen_istft_hop_size = gen_istft_hop_size
 
+        if is_onnx:
+            self.stft = STFT(filter_length=self.gen_istft_n_fft, hop_length=self.gen_istft_hop_size,
+                    win_length=self.gen_istft_n_fft)       
+        else:
+            self.stft = TorchSTFT(filter_length=self.gen_istft_n_fft, hop_length=self.gen_istft_hop_size,
+                    win_length=self.gen_istft_n_fft)
+
+        self.stft = stft_onnx.STFT(
+            MAX_FRAMES,
+            filter_length=self.gen_istft_n_fft,
+            hop_length=self.gen_istft_hop_size,
+            win_length=self.gen_istft_n_fft,
+            window="hann"
+          )
+        
+        self.istft = stft_onnx.ExportableISTFTModule(
+            MAX_FRAMES,
+            filter_length=self.gen_istft_n_fft,
+            hop_length=self.gen_istft_hop_size,
+            win_length=self.gen_istft_n_fft,
+        )
 
     def forward(self, x, g=None):
-      stft = TorchSTFT(filter_length=self.gen_istft_n_fft, hop_length=self.gen_istft_hop_size, win_length=self.gen_istft_n_fft).to(x.device)
       pqmf = PQMF(x.device)
       
       x = self.conv_pre(x)#[B, ch, length]
@@ -366,8 +397,10 @@ class Multiband_iSTFT_Generator(torch.nn.Module):
       spec = torch.exp(x[:,:,:self.post_n_fft // 2 + 1, :])
       phase = math.pi*torch.sin(x[:,:, self.post_n_fft // 2 + 1:, :])
 
-      y_mb_hat = stft.inverse(torch.reshape(spec, (spec.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, spec.shape[-1])), torch.reshape(phase, (phase.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, phase.shape[-1])))
-      y_mb_hat = torch.reshape(y_mb_hat, (x.shape[0], self.subbands, 1, y_mb_hat.shape[-1]))
+      a = torch.reshape(spec, (spec.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, spec.shape[-1]))
+      b = torch.reshape(phase, (phase.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, phase.shape[-1]))
+
+      y_mb_hat = self.istft(a, b)
       y_mb_hat = y_mb_hat.squeeze(-2)
 
       y_g_hat = pqmf.synthesis(y_mb_hat)
@@ -422,7 +455,6 @@ class Multistream_iSTFT_Generator(torch.nn.Module):
         self.register_buffer("updown_filter", updown_filter)
         self.multistream_conv_post = weight_norm(Conv1d(4, 1, kernel_size=63, bias=False, padding=get_padding(63, 1)))
         self.multistream_conv_post.apply(init_weights)
-        
 
 
     def forward(self, x, g=None):
@@ -454,11 +486,14 @@ class Multistream_iSTFT_Generator(torch.nn.Module):
       spec = torch.exp(x[:,:,:self.post_n_fft // 2 + 1, :])
       phase = math.pi*torch.sin(x[:,:, self.post_n_fft // 2 + 1:, :])
 
+
       y_mb_hat = stft.inverse(torch.reshape(spec, (spec.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, spec.shape[-1])), torch.reshape(phase, (phase.shape[0]*self.subbands, self.gen_istft_n_fft // 2 + 1, phase.shape[-1])))
+
       y_mb_hat = torch.reshape(y_mb_hat, (x.shape[0], self.subbands, 1, y_mb_hat.shape[-1]))
       y_mb_hat = y_mb_hat.squeeze(-2)
 
-      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cuda(x.device) * self.subbands, stride=self.subbands)
+      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cpu() * self.subbands, stride=self.subbands)
+      #y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cuda(x.device) * self.subbands, stride=self.subbands)
 
       y_g_hat = self.multistream_conv_post(y_mb_hat)
 
@@ -594,6 +629,7 @@ class SynthesizerTrn(nn.Module):
     mb_istft_vits = False,
     subbands = False,
     istft_vits=False,
+    is_onnx=False,
     **kwargs):
 
     super().__init__()
@@ -631,7 +667,7 @@ class SynthesizerTrn(nn.Module):
         p_dropout)
     if mb_istft_vits == True:
       print('Mutli-band iSTFT VITS')
-      self.dec = Multiband_iSTFT_Generator(inter_channels, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size, subbands, gin_channels=gin_channels)
+      self.dec = Multiband_iSTFT_Generator(inter_channels, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size, subbands, gin_channels=gin_channels, is_onnx=is_onnx)
     elif ms_istft_vits == True:
       print('Mutli-stream iSTFT VITS')
       self.dec = Multistream_iSTFT_Generator(inter_channels, resblock, resblock_kernel_sizes, resblock_dilation_sizes, upsample_rates, upsample_initial_channel, upsample_kernel_sizes, gen_istft_n_fft, gen_istft_hop_size, subbands, gin_channels=gin_channels)
@@ -691,6 +727,7 @@ class SynthesizerTrn(nn.Module):
     z_slice, ids_slice = commons.rand_slice_segments(z, y_lengths, self.segment_size)
     o, o_mb = self.dec(z_slice, g=g)
     return o, o_mb, l_length, attn, ids_slice, x_mask, y_mask, (z, z_p, m_p, logs_p, m_q, logs_q)
+
 
   def infer(self, x, x_lengths, sid=None, noise_scale=1, length_scale=1, noise_scale_w=1., max_len=None):
     x, m_p, logs_p, x_mask = self.enc_p(x, x_lengths)

--- a/models.py
+++ b/models.py
@@ -1,20 +1,21 @@
+import copy
 import math
 import torch
-import stft_onnx
+from torch import nn
+from torch.nn import functional as F
+
 import commons
 import modules
 import attentions
 import monotonic_align
-import math
+import stft_onnx
 
-from torch import nn
-from torch.nn import functional as F
-from torch.nn import Conv1d, ConvTranspose1d, Conv2d
+from torch.nn import Conv1d, ConvTranspose1d, AvgPool1d, Conv2d
 from torch.nn.utils import weight_norm, remove_weight_norm, spectral_norm
 from commons import init_weights, get_padding
 from pqmf import PQMF
-from stft import TorchSTFT
-from stft import STFT
+from stft import TorchSTFT, STFT
+import math
 
 MAX_FRAMES = 5200
 
@@ -457,6 +458,7 @@ class Multistream_iSTFT_Generator(torch.nn.Module):
         self.multistream_conv_post.apply(init_weights)
 
 
+
     def forward(self, x, g=None):
       stft = TorchSTFT(filter_length=self.gen_istft_n_fft, hop_length=self.gen_istft_hop_size, win_length=self.gen_istft_n_fft).to(x.device)
       # pqmf = PQMF(x.device)
@@ -492,8 +494,7 @@ class Multistream_iSTFT_Generator(torch.nn.Module):
       y_mb_hat = torch.reshape(y_mb_hat, (x.shape[0], self.subbands, 1, y_mb_hat.shape[-1]))
       y_mb_hat = y_mb_hat.squeeze(-2)
 
-      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cpu() * self.subbands, stride=self.subbands)
-      #y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.cuda(x.device) * self.subbands, stride=self.subbands)
+      y_mb_hat = F.conv_transpose1d(y_mb_hat, self.updown_filter.to(x.device) * self.subbands, stride=self.subbands)
 
       y_g_hat = self.multistream_conv_post(y_mb_hat)
 
@@ -727,7 +728,6 @@ class SynthesizerTrn(nn.Module):
     z_slice, ids_slice = commons.rand_slice_segments(z, y_lengths, self.segment_size)
     o, o_mb = self.dec(z_slice, g=g)
     return o, o_mb, l_length, attn, ids_slice, x_mask, y_mask, (z, z_p, m_p, logs_p, m_q, logs_q)
-
 
   def infer(self, x, x_lengths, sid=None, noise_scale=1, length_scale=1, noise_scale_w=1., max_len=None):
     x, m_p, logs_p, x_mask = self.enc_p(x, x_lengths)

--- a/pqmf.py
+++ b/pqmf.py
@@ -75,15 +75,15 @@ class PQMF(torch.nn.Module):
                 (-1) ** k * np.pi / 4)
 
         # convert to tensor
-        analysis_filter = torch.from_numpy(h_analysis).float().unsqueeze(1).cuda(device)
-        synthesis_filter = torch.from_numpy(h_synthesis).float().unsqueeze(0).cuda(device)
+        analysis_filter = torch.from_numpy(h_analysis).float().unsqueeze(1).to(device)
+        synthesis_filter = torch.from_numpy(h_synthesis).float().unsqueeze(0).to(device)
 
         # register coefficients as beffer
         self.register_buffer("analysis_filter", analysis_filter)
         self.register_buffer("synthesis_filter", synthesis_filter)
 
         # filter for downsampling & upsampling
-        updown_filter = torch.zeros((subbands, subbands, subbands)).float().cuda(device)
+        updown_filter = torch.zeros((subbands, subbands, subbands)).float().to(device)
         for k in range(subbands):
             updown_filter[k, k, 0] = 1.0
         self.register_buffer("updown_filter", updown_filter)
@@ -99,8 +99,8 @@ class PQMF(torch.nn.Module):
         Returns:
             Tensor: Output tensor (B, subbands, T // subbands).
         """
-        x = F.conv1d(self.pad_fn(x), self.analysis_filter)
-        return F.conv1d(x, self.updown_filter, stride=self.subbands)
+        x = F.conv1d(self.pad_fn(x), self.analysis_filter.to(x.device))
+        return F.conv1d(x, self.updown_filter.to(x.device), stride=self.subbands)
 
     def synthesis(self, x):
         """Synthesis with PQMF.
@@ -112,5 +112,5 @@ class PQMF(torch.nn.Module):
         # NOTE(kan-bayashi): Power will be dreased so here multipy by # subbands.
         #   Not sure this is the correct way, it is better to check again.
         # TODO(kan-bayashi): Understand the reconstruction procedure
-        x = F.conv_transpose1d(x, self.updown_filter * self.subbands, stride=self.subbands)
-        return F.conv1d(self.pad_fn(x), self.synthesis_filter)
+        x = F.conv_transpose1d(x, self.updown_filter.to(x.device) * self.subbands, stride=self.subbands)
+        return F.conv1d(self.pad_fn(x), self.synthesis_filter.to(x.device))

--- a/stft_onnx.py
+++ b/stft_onnx.py
@@ -1,0 +1,271 @@
+# coding: utf-8
+
+# BSD 3-Clause License
+# Copyright (c) 2017, Prem Seetharaman
+# Copyright (c) 2024, Musharraf Omer
+# All rights reserved.
+# * Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+# * Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from this
+# software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import logging
+import random
+from pathlib import Path
+
+import numpy as np
+import torch
+from librosa import util as librosa_util
+from librosa.util import pad_center, tiny
+from scipy.signal import get_window
+from torch import nn
+from torch.autograd import Variable
+from torch.nn import functional as F
+
+# Calculate as: (seconds * sample_rate) / hop_size
+# Common values (22.05KHz): 30 secs=~2600 mels, 60 secs=~5200 mels, 100 secs=~8620 mels
+# This determines model size
+MAX_FRAMES = 5200
+
+DEFAULT_OPSET = 17
+DEFAULT_SEED = 1234
+_LOGGER = logging.getLogger("piper_train.export_onnx")
+
+
+class STFT(torch.nn.Module):
+    """adapted from Prem Seetharaman's https://github.com/pseeth/pytorch-stft"""
+
+    def __init__(self, max_frames, filter_length, hop_length, win_length, window):
+        super(STFT, self).__init__()
+        self.filter_length = filter_length
+        self.hop_length = hop_length
+        self.win_length = win_length
+        self.window = window
+        self.forward_transform = None
+        scale = self.filter_length / self.hop_length
+        fourier_basis = np.fft.fft(np.eye(self.filter_length))
+
+        cutoff = int((self.filter_length / 2 + 1))
+        fourier_basis = np.vstack(
+            [np.real(fourier_basis[:cutoff, :]), np.imag(fourier_basis[:cutoff, :])]
+        )
+
+        forward_basis = torch.FloatTensor(fourier_basis[:, None, :])
+        inverse_basis = torch.FloatTensor(
+            np.linalg.pinv(scale * fourier_basis).T[:, None, :]
+        )
+        if window is not None:
+            assert filter_length >= win_length
+            # get window and zero center pad it to filter_length
+            fft_window = get_window(window, win_length, fftbins=True)
+            fft_window = pad_center(fft_window, size=filter_length)
+            fft_window = torch.from_numpy(fft_window).float()
+            # window the bases
+            forward_basis *= fft_window
+            inverse_basis *= fft_window
+        window_sum = self.window_sumsquare(
+            self.window,
+            max_frames,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            n_fft=self.filter_length,
+            dtype=np.float32,
+        )
+        self.register_buffer("forward_basis", forward_basis.float())
+        self.register_buffer("inverse_basis", inverse_basis.float())
+        self.register_buffer("window_sum", torch.from_numpy(window_sum))
+        self.tiny = tiny(window_sum)
+
+    def forward(self, magnitude, phase):
+        recombine_magnitude_phase = torch.cat(
+            [magnitude * torch.cos(phase), magnitude * torch.sin(phase)], dim=1
+        )
+        inverse_transform = F.conv_transpose1d(
+            recombine_magnitude_phase,
+            Variable(self.inverse_basis, requires_grad=False),
+            stride=self.hop_length,
+            padding=0,
+        )
+        self.window = None
+        if self.window is not None:
+            win_dim = inverse_transform.size(-1)
+            window_sum = self.window_sum[:win_dim]
+            # remove modulation effects
+            inverse_transform = inverse_transform.squeeze()
+            approx_nonzero_indices = (window_sum > self.tiny).nonzero()
+            inverse_transform[approx_nonzero_indices] /= window_sum[
+                approx_nonzero_indices
+            ]
+            inverse_transform = inverse_transform.unsqueeze(0).unsqueeze(1)
+            # scale by hop ratio
+            inverse_transform *= float(self.filter_length) / self.hop_length
+        inverse_transform = inverse_transform[:, :, int(self.filter_length / 2) :]
+        inverse_transform = inverse_transform[:, :, : -int(self.filter_length / 2) :]
+        return inverse_transform
+
+    @staticmethod
+    def window_sumsquare(
+        window,
+        n_frames,
+        hop_length=200,
+        win_length=800,
+        n_fft=800,
+        dtype=np.float32,
+        norm=None,
+    ):
+        """
+        # from librosa 0.6
+        Compute the sum-square envelope of a window function at a given hop length.
+        This is used to estimate modulation effects induced by windowing
+        observations in short-time fourier transforms.
+        Parameters
+        ----------
+        window : string, tuple, number, callable, or list-like
+            Window specification, as in `get_window`
+        n_frames : int > 0
+            The number of analysis frames
+        hop_length : int > 0
+            The number of samples to advance between frames
+        win_length : [optional]
+            The length of the window function.  By default, this matches `n_fft`.
+        n_fft : int > 0
+            The length of each analysis frame.
+        dtype : np.dtype
+            The data type of the output
+        Returns
+        -------
+        wss : np.ndarray, shape=`(n_fft + hop_length * (n_frames - 1))`
+            The sum-squared envelope of the window function
+        """
+        if win_length is None:
+            win_length = n_fft
+
+        n = n_fft + hop_length * (n_frames - 1)
+        x = np.zeros(n, dtype=dtype)
+
+        # Compute the squared window at the desired length
+        win_sq = get_window(window, win_length, fftbins=True)
+        win_sq = librosa_util.normalize(win_sq, norm=norm) ** 2
+        win_sq = librosa_util.pad_center(win_sq, size=n_fft)
+
+        # Fill the envelope
+        for i in range(n_frames):
+            sample = i * hop_length
+            x[sample : min(n, sample + n_fft)] += win_sq[
+                : max(0, min(n_fft, n - sample))
+            ]
+        return x
+
+
+class ExportableISTFTModule(nn.Module):
+    def __init__(
+        self, max_frames, filter_length, hop_length, win_length, window="hann"
+    ):
+        super().__init__()
+        self.stft = STFT(
+            max_frames,
+            filter_length=filter_length,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+        )
+
+    # def forward(self, mag, x, y):
+    def forward(self, mag, phase):
+        # phase = torch.atan2(y, x)
+        return self.stft(mag, phase)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description="Export ISTFT to ONNX")
+
+    parser.add_argument("output", type=str, help="Path to output `.onnx` file")
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=MAX_FRAMES,
+        help="Max number of frames decodable by this model",
+    )
+    parser.add_argument("--nfft", type=int, default=1024, help="filter-length")
+    parser.add_argument("--hop", type=int, default=256, help="hop-length")
+    parser.add_argument("--win", type=int, default=1024, help="win-length")
+    parser.add_argument("--win-type", type=str, default="hann", help="window type")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed")
+    parser.add_argument(
+        "--opset", type=int, default=DEFAULT_OPSET, help="ONNX opset version to use"
+    )
+
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+    _LOGGER.info("Exporting ISTFT to ONNX")
+    _LOGGER.info(f"Max frames  decodable by exported model: {args.max_frames}")
+    _LOGGER.info(
+        "ISTFT parameters:\n"
+        f"\tfilter-length: {args.nfft}\n"
+        f"\thop-length: {args.hop}\n"
+        f"\twin-length: {args.win}\n"
+        f"\twin-type: `{args.win_type}`"
+    )
+    istft_model = ExportableISTFTModule(
+        args.max_frames,
+        filter_length=args.nfft,
+        hop_length=args.hop,
+        win_length=args.win,
+        window=args.win_type,
+    )
+    dynamic_axes = {
+        "audio": {0: "batch", 2: "time"},
+        "mag": {0: "Clipmag_dim_0", 1: "Clipmag_dim_1", 2: "Clipmag_dim_2"},
+        "x": {0: "Clipmag_dim_0", 1: "Cosx_dim_1", 2: "Clipmag_dim_2"},
+        "y": {0: "Clipmag_dim_0", 1: "Cosx_dim_1", 2: "Clipmag_dim_2"},
+    }
+    n_freqs = int(args.win / 2) + 1
+    n_mels = 10
+    assert (
+        n_mels < MAX_FRAMES
+    ), f"MAX_FRAMES `{MAX_FRAMES}` must be greater than `{n_mels}`"
+    dummy_input = tuple(
+        torch.rand((1, n_freqs, n_mels), dtype=torch.float32) for i in range(3)
+    )
+    torch.onnx.export(
+        istft_model,
+        args=dummy_input,
+        f=args.output,
+        input_names=["mag", "x", "y"],
+        output_names=["audio"],
+        dynamic_axes=dynamic_axes,
+        export_params=True,
+        do_constant_folding=True,
+        opset_version=args.opset,
+    )
+    _LOGGER.info(f"Exported ONNX graph to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Implementation includes:

- Extension of MB-iSTFT-VITS repository to support exporting of trained checkpoints to ONNX format.
- Running inference with the exported ONNX models.

The implementation aims to respect the current structure as well as keep the existing functionality intact. 
It resolves both issues https://github.com/MasayaKawamura/MB-iSTFT-VITS/issues/8 and https://github.com/MasayaKawamura/MB-iSTFT-VITS/issues/20 .

# Changes Made
Please note that to export to ONNX and run inference, additional packages must be installed. After setting up the environment as described above, install the following packages. This setup has been tested with ```Python 3.8```:

- For ONNX export: ```torch==1.12.0```
- For ONNX inference: ```onnxruntime==1.18.0```

## Example command line:
Here we specify the device using the --device argument:
- ```python export_onnx.py  --model {model_ckpt}.pth --config-path config.json --output-onnx-path {path_to_exported}.onnx --device 'cpu'```
- ``` python infer_onnx.py --model {path_to_exported}.onnx --config-path config.json --output-wav-path output.wav --text "Hello world, how are you doing?"```